### PR TITLE
More meetups and search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,28 +2,28 @@ GEM
   remote: https://rubygems.org/
   specs:
     camertron-eprun (1.1.0)
-    cldr-plurals-runtime-rb (1.0.0)
-    daemons (1.1.9)
-    dotenv (1.0.2)
-    eventmachine (1.0.4)
-    httparty (0.13.3)
+    cldr-plurals-runtime-rb (1.0.1)
+    daemons (1.2.3)
+    dotenv (2.0.2)
+    eventmachine (1.0.8)
+    httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    json (1.8.1)
+    json (1.8.3)
     multi_xml (0.5.5)
-    rack (1.6.0)
+    rack (1.6.4)
     rack-protection (1.5.3)
       rack
-    sinatra (1.4.5)
+    sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    thin (1.6.3)
+      tilt (>= 1.3, < 3)
+    thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0)
+      eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
     thread_safe (0.3.5)
-    tilt (1.4.1)
+    tilt (2.0.1)
     twitter_cldr (3.2.1)
       camertron-eprun
       cldr-plurals-runtime-rb (~> 1.0.0)
@@ -41,3 +41,6 @@ DEPENDENCIES
   sinatra
   thin
   twitter_cldr
+
+BUNDLED WITH
+   1.10.6

--- a/app.rb
+++ b/app.rb
@@ -30,7 +30,7 @@ post "/" do
 end
 
 def generate_attachment
-  uri = "https://api.meetup.com/2/events?group_urlname=#{ENV["MEETUP_GROUP_URL"]}&page=1&key=#{ENV["MEETUP_API_KEY"]}"
+  uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=1&key=#{ENV["MEETUP_API_KEY"]}"
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"
 

--- a/app.rb
+++ b/app.rb
@@ -30,7 +30,12 @@ post "/" do
 end
 
 def generate_attachment
-  uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
+  if ENV["MEETUP_GROUP_URL"].nil?
+    uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
+  else
+    uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_URL"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
+  end
+
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"
 

--- a/app.rb
+++ b/app.rb
@@ -33,7 +33,7 @@ end
 
 def generate_attachment
   @user_query = params[:text]
-if params[:text].nil?
+if params[:text].match("")
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
   uri = "https://api.meetup.com/2/open_events?text='#{@user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"

--- a/app.rb
+++ b/app.rb
@@ -30,12 +30,7 @@ post "/" do
 end
 
 def generate_attachment
-  if ENV["MEETUP_GROUP_URL"].nil?
-    uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
-  else
-    uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_URL"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
-  end
-
+  uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"
 

--- a/app.rb
+++ b/app.rb
@@ -33,7 +33,7 @@ end
 
 def generate_attachment
   user_query = params[:text]
-if user_query.nil?
+if user_query = ""
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
   uri = "https://api.meetup.com/2/open_events?text='#{user_query}''&page=2&key=#{ENV["MEETUP_API_KEY"]}"

--- a/app.rb
+++ b/app.rb
@@ -57,8 +57,9 @@ def generate_attachment
   get_firstwaitlistcount = @firstresults["waitlist_count"]
   raw_firsttime = @firstresults["time"].to_f / 1000
   utc_firstoffset = @firstresults["utc_offset"].to_i / 1000
-  calc_firsttime = Time.at(raw_firsttime) #.getlocal(utc_firstoffset)
-  cldr_firsttime = calc_firsttime.localize
+  calc_firsttime = raw_firsttime + utc_firstoffset
+  final_firsttime = Time.at(calc_firsttime)
+  cldr_firsttime = final_firsttime.localize
   get_firsttime = "#{cldr_firsttime.to_short_s} #{cldr_firsttime.to_date.to_full_s}"
   end
 
@@ -82,8 +83,9 @@ def generate_attachment
   get_secondurl = @secondresults["event_url"]
   raw_secondtime = @secondresults["time"].to_f / 1000
   utc_secondoffset = @secondresults["utc_offset"].to_i / 1000
-  calc_secondtime = Time.at(raw_secondtime) #.getlocal(utc_secondoffset)
-  cldr_secondtime = calc_secondtime.localize
+  calc_secondtime = raw_secondtime + utc_secondoffset
+  final_secondtime = Time.at(calc_secondtime)
+  cldr_secondtime = final_secondtime.localize
   get_secondtime = "#{cldr_secondtime.to_short_s} #{cldr_secondtime.to_date.to_full_s}"
 
   response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", fields: [ { title: "RSVPs", value: "#{get_firstrsvpcount}", short: true }, { title: "Waitlist", value: "#{get_firstwaitlistcount}", short: true }, { title: "Following Meetup:", value: "<#{get_secondurl}|#{get_secondname}> - #{get_secondtime}", short: false } ] }

--- a/app.rb
+++ b/app.rb
@@ -55,7 +55,7 @@ def generate_attachment
   get_firsturl = @firstresults["event_url"]
   raw_firsttime = @firstresults["time"].to_f / 1000
   utc_firstoffset = @firstresults["utc_offset"].to_i / 1000
-  calc_firsttime = Time.at(raw_firsttime).getlocal(utc_offset)
+  calc_firsttime = Time.at(raw_firsttime).getlocal(utc_firstoffset)
   cldr_firsttime = calc_firsttime.localize
   get_firsttime = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
   end
@@ -80,7 +80,7 @@ def generate_attachment
   get_secondurl = @secondresults["event_url"]
   raw_secondtime = @secondresults["time"].to_f / 1000
   utc_secondoffset = @secondresults["utc_offset"].to_i / 1000
-  calc_secondtime = Time.at(raw_secondtime).getlocal(utc_offset)
+  calc_secondtime = Time.at(raw_secondtime).getlocal(utc_secondoffset)
   cldr_secondtime = calc_secondtime.localize
   get_secondtime = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
 

--- a/app.rb
+++ b/app.rb
@@ -84,7 +84,7 @@ def generate_attachment
   cldr_secondtime = calc_secondtime.localize
   get_secondtime = "#{cldr_secondtime.to_short_s} #{cldr_secondtime.to_date.to_full_s}"
 
-  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firstime}\n#{firstlocation}", color: "#{ENV["COLOR"]}"}
+  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", color: "#{ENV["COLOR"]}"}
   end
 
 end

--- a/app.rb
+++ b/app.rb
@@ -33,7 +33,7 @@ end
 
 def generate_attachment
   user_query = params[:text]
-if user_query.nil?
+if user_query.match(/^/i)
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
   uri = "https://api.meetup.com/2/open_events?text='#{user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"

--- a/app.rb
+++ b/app.rb
@@ -33,10 +33,10 @@ end
 
 def generate_attachment
   user_query = params[:text]
-if user_query = ""
+if user_query = ".meetup"
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
-  uri = "https://api.meetup.com/2/open_events?text='#{user_query}''&page=2&key=#{ENV["MEETUP_API_KEY"]}"
+  uri = "https://api.meetup.com/2/open_events?text='#{user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 end
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"

--- a/app.rb
+++ b/app.rb
@@ -33,7 +33,7 @@ end
 
 def generate_attachment
   @user_query = params[:text]
-if params[:text].length == 0
+if @user_query.length == 0
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
   uri = "https://api.meetup.com/2/open_events?text='#{@user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"

--- a/app.rb
+++ b/app.rb
@@ -36,7 +36,7 @@ def generate_attachment
 if @user_query.length == 0
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
-  uri = "https://api.meetup.com/2/open_events?text='#{@user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
+  uri = "https://api.meetup.com/2/open_events?topic='#{@user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 end
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"

--- a/app.rb
+++ b/app.rb
@@ -33,7 +33,7 @@ end
 
 def generate_attachment
   user_query = params[:text]
-if user_query = ".meetup"
+if user_query.nil
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
   uri = "https://api.meetup.com/2/open_events?text='#{user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"

--- a/app.rb
+++ b/app.rb
@@ -57,7 +57,7 @@ def generate_attachment
   utc_firstoffset = @firstresults["utc_offset"].to_i / 1000
   calc_firsttime = Time.at(raw_firsttime).getlocal(utc_firstoffset)
   cldr_firsttime = calc_firsttime.localize
-  get_firsttime = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
+  get_firsttime = "#{cldr_firsttime.to_short_s} #{cldr_firsttime.to_date.to_full_s}"
   end
 
   # Second Meetup
@@ -82,7 +82,7 @@ def generate_attachment
   utc_secondoffset = @secondresults["utc_offset"].to_i / 1000
   calc_secondtime = Time.at(raw_secondtime).getlocal(utc_secondoffset)
   cldr_secondtime = calc_secondtime.localize
-  get_secondtime = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
+  get_secondtime = "#{cldr_secondtime.to_short_s} #{cldr_secondtime.to_date.to_full_s}"
 
   response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firstime}\n#{firstlocation}", color: "#{ENV["COLOR"]}"}
   end

--- a/app.rb
+++ b/app.rb
@@ -36,7 +36,7 @@ def generate_attachment
 if @user_query.length == 0
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
-  uri = "https://api.meetup.com/2/open_events?topic='#{@user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
+  uri = "https://api.meetup.com/2/open_events?topic=#{@user_query}&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 end
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"

--- a/app.rb
+++ b/app.rb
@@ -57,7 +57,7 @@ def generate_attachment
   get_firstwaitlistcount = @firstresults["waitlist_count"]
   raw_firsttime = @firstresults["time"].to_f / 1000
   utc_firstoffset = @firstresults["utc_offset"].to_i / 1000
-  calc_firsttime = Time.at(raw_firsttime).getlocal(utc_firstoffset)
+  calc_firsttime = Time.at(raw_firsttime).getlocal("utc_firstoffset")
   cldr_firsttime = calc_firsttime.localize
   get_firsttime = "#{cldr_firsttime.to_short_s} #{cldr_firsttime.to_date.to_full_s}"
   end
@@ -82,7 +82,7 @@ def generate_attachment
   get_secondurl = @secondresults["event_url"]
   raw_secondtime = @secondresults["time"].to_f / 1000
   utc_secondoffset = @secondresults["utc_offset"].to_i / 1000
-  calc_secondtime = Time.at(raw_secondtime).getlocal(utc_secondoffset)
+  calc_secondtime = Time.at(raw_secondtime).getlocal("utc_secondoffset")
   cldr_secondtime = calc_secondtime.localize
   get_secondtime = "#{cldr_secondtime.to_short_s} #{cldr_secondtime.to_date.to_full_s}"
 

--- a/app.rb
+++ b/app.rb
@@ -33,7 +33,7 @@ end
 
 def generate_attachment
   user_query = params[:text]
-if user_query.nil
+if user_query = ""
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
   uri = "https://api.meetup.com/2/open_events?text='#{user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
@@ -95,7 +95,7 @@ end
   cldr_secondtime = final_secondtime.localize
   get_secondtime = "#{cldr_secondtime.to_short_s} #{cldr_secondtime.to_date.to_full_s}"
 
-  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", fields: [ { title: "RSVPs", value: "#{get_firstrsvpcount}", short: true }, { title: "Waitlist", value: "#{get_firstwaitlistcount}", short: true }, { title: "Following Meetup:", value: "<#{get_secondurl}|#{get_secondname}> - #{get_secondtime}", short: false } ] }
+  response = { title: "#{user_query}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", fields: [ { title: "RSVPs", value: "#{get_firstrsvpcount}", short: true }, { title: "Waitlist", value: "#{get_firstwaitlistcount}", short: true }, { title: "Following Meetup:", value: "<#{get_secondurl}|#{get_secondname}> - #{get_secondtime}", short: false } ] }
   end
 
 end

--- a/app.rb
+++ b/app.rb
@@ -30,7 +30,7 @@ post "/" do
 end
 
 def generate_attachment
-  uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=1&key=#{ENV["MEETUP_API_KEY"]}"
+  uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=3&key=#{ENV["MEETUP_API_KEY"]}"
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"
 

--- a/app.rb
+++ b/app.rb
@@ -34,7 +34,7 @@ end
 def generate_attachment
   @user_query = params[:text]
   puts "#{@user_query}"
-if @user_query.nil?
+if @user_query = " "
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
   uri = "https://api.meetup.com/2/open_events?text='#{@user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"

--- a/app.rb
+++ b/app.rb
@@ -55,7 +55,7 @@ def generate_attachment
   get_firsturl = @firstresults["event_url"]
   raw_firsttime = @firstresults["time"].to_f / 1000
   utc_firstoffset = @firstresults["utc_offset"].to_i / 1000
-  calc_firsttime = Time.at(raw_time).getlocal(utc_offset)
+  calc_firsttime = Time.at(raw_firsttime).getlocal(utc_offset)
   cldr_firsttime = calc_firsttime.localize
   get_firsttime = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
   end
@@ -80,7 +80,7 @@ def generate_attachment
   get_secondurl = @secondresults["event_url"]
   raw_secondtime = @secondresults["time"].to_f / 1000
   utc_secondoffset = @secondresults["utc_offset"].to_i / 1000
-  calc_secondtime = Time.at(raw_time).getlocal(utc_offset)
+  calc_secondtime = Time.at(raw_secondtime).getlocal(utc_offset)
   cldr_secondtime = calc_secondtime.localize
   get_secondtime = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
 

--- a/app.rb
+++ b/app.rb
@@ -86,7 +86,7 @@ def generate_attachment
   cldr_secondtime = calc_secondtime.localize
   get_secondtime = "#{cldr_secondtime.to_short_s} #{cldr_secondtime.to_date.to_full_s}"
 
-  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", color: "#{ENV["COLOR"]}", fields: [ { title: "RSVPs", value: "#{get_firstrsvpcount}", short: true }, { title: "Waitlist", value: "#{get_firstwaitlistcount}", short: true }, { title: "Next Meetup:", value: "<#{get_secondurl}|#{get_secondname}>, #{get_secondtime}", short: false } ] }
+  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", color: "#{ENV["COLOR"]}", fields: [ { title: "RSVPs", value: "#{get_firstrsvpcount}", short: true }, { title: "Waitlist", value: "#{get_firstwaitlistcount}", short: true }, { title: "Following Meetup:", value: "<#{get_secondurl}|#{get_secondname}> - #{get_secondtime}", short: false } ] }
   end
 
 end

--- a/app.rb
+++ b/app.rb
@@ -53,6 +53,8 @@ def generate_attachment
   end
   get_firstname = @firstresults["name"]
   get_firsturl = @firstresults["event_url"]
+  get_firstrsvpcount = @firstresults["yes_rsvp_count"]
+  get_firstwaitlistcount = @firstresults["waitlist_count"]
   raw_firsttime = @firstresults["time"].to_f / 1000
   utc_firstoffset = @firstresults["utc_offset"].to_i / 1000
   calc_firsttime = Time.at(raw_firsttime).getlocal(utc_firstoffset)
@@ -84,7 +86,7 @@ def generate_attachment
   cldr_secondtime = calc_secondtime.localize
   get_secondtime = "#{cldr_secondtime.to_short_s} #{cldr_secondtime.to_date.to_full_s}"
 
-  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", color: "#{ENV["COLOR"]}"}
+  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", color: "#{ENV["COLOR"]}", fields: [ { title: "RSVPs", value: "#{get_firstrsvpcount}", short: true }, { title: "Waitlist", value: "#{get_firstwaitlistcount}", short: true }, { title: "Next Meetup:", value: "<#{get_secondurl}|#{get_secondname}>, #{get_secondtime}", short: false } ] }
   end
 
 end

--- a/app.rb
+++ b/app.rb
@@ -32,11 +32,12 @@ end
 end
 
 def generate_attachment
-  user_query = params[:text]
-if user_query.match(/^/i)
+  @user_query = params[:text]
+  puts "#{@user_query}"
+if @user_query.nil?
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
-  uri = "https://api.meetup.com/2/open_events?text='#{user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
+  uri = "https://api.meetup.com/2/open_events?text='#{@user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 end
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"

--- a/app.rb
+++ b/app.rb
@@ -33,8 +33,7 @@ end
 
 def generate_attachment
   @user_query = params[:text]
-  puts "#{@user_query}"
-if @user_query = " "
+if params[:text].nil?
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
   uri = "https://api.meetup.com/2/open_events?text='#{@user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"

--- a/app.rb
+++ b/app.rb
@@ -33,7 +33,7 @@ end
 
 def generate_attachment
   user_query = params[:text]
-if user_query = ""
+if user_query.nil?
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
   uri = "https://api.meetup.com/2/open_events?text='#{user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
@@ -95,7 +95,7 @@ end
   cldr_secondtime = final_secondtime.localize
   get_secondtime = "#{cldr_secondtime.to_short_s} #{cldr_secondtime.to_date.to_full_s}"
 
-  response = { title: "#{user_query}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", fields: [ { title: "RSVPs", value: "#{get_firstrsvpcount}", short: true }, { title: "Waitlist", value: "#{get_firstwaitlistcount}", short: true }, { title: "Following Meetup:", value: "<#{get_secondurl}|#{get_secondname}> - #{get_secondtime}", short: false } ] }
+  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", fields: [ { title: "RSVPs", value: "#{get_firstrsvpcount}", short: true }, { title: "Waitlist", value: "#{get_firstwaitlistcount}", short: true }, { title: "Following Meetup:", value: "<#{get_secondurl}|#{get_secondname}> - #{get_secondtime}", short: false } ] }
   end
 
 end

--- a/app.rb
+++ b/app.rb
@@ -33,7 +33,7 @@ end
 
 def generate_attachment
   @user_query = params[:text]
-if params[:text].match("")
+if params[:text].length == 0
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
   uri = "https://api.meetup.com/2/open_events?text='#{@user_query}'&zip=#{ENV["ZIP_CODE"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"

--- a/app.rb
+++ b/app.rb
@@ -57,7 +57,7 @@ def generate_attachment
   get_firstwaitlistcount = @firstresults["waitlist_count"]
   raw_firsttime = @firstresults["time"].to_f / 1000
   utc_firstoffset = @firstresults["utc_offset"].to_i / 1000
-  calc_firsttime = Time.at(raw_firsttime).getlocal("utc_firstoffset")
+  calc_firsttime = Time.at(raw_firsttime) #.getlocal(utc_firstoffset)
   cldr_firsttime = calc_firsttime.localize
   get_firsttime = "#{cldr_firsttime.to_short_s} #{cldr_firsttime.to_date.to_full_s}"
   end
@@ -82,7 +82,7 @@ def generate_attachment
   get_secondurl = @secondresults["event_url"]
   raw_secondtime = @secondresults["time"].to_f / 1000
   utc_secondoffset = @secondresults["utc_offset"].to_i / 1000
-  calc_secondtime = Time.at(raw_secondtime).getlocal("utc_secondoffset")
+  calc_secondtime = Time.at(raw_secondtime) #.getlocal(utc_secondoffset)
   cldr_secondtime = calc_secondtime.localize
   get_secondtime = "#{cldr_secondtime.to_short_s} #{cldr_secondtime.to_date.to_full_s}"
 

--- a/app.rb
+++ b/app.rb
@@ -16,7 +16,9 @@ end
 
 post "/" do
   response = ""
-
+begin
+  puts "[LOG] #{params}"
+  params[:text] = params[:text].sub(params[:trigger_word], "").strip
   unless params[:token] != ENV["OUTGOING_WEBHOOK_TOKEN"]
     response = { text: "Next Meetup:" }
     response[:attachments] = [ generate_attachment ]
@@ -24,13 +26,18 @@ post "/" do
     response[:icon_emoji] = ENV["BOT_ICON"] unless ENV["BOT_ICON"].nil?
     response = response.to_json
   end
-
+end
   status 200
   body response
 end
 
 def generate_attachment
+  user_query = params[:text]
+if user_query.nil?
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
+else
+  uri = "https://api.meetup.com/2/open_events?topic='#{user_query}''&page=2&key=#{ENV["MEETUP_API_KEY"]}"
+end
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"
 

--- a/app.rb
+++ b/app.rb
@@ -30,37 +30,60 @@ post "/" do
 end
 
 def generate_attachment
-  uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=3&key=#{ENV["MEETUP_API_KEY"]}"
+  uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"
 
   # Check for a nil response in the array
-  @results = JSON.parse(request.body)["results"][0]
-  if @results.nil?
+  @firstresults = JSON.parse(request.body)["results"][0]
+  @secondresults = JSON.parse(request.body)["results"][1]
+
+  # First Meetup
+  if @firstresults.nil?
     response = { title: "No upcoming Meetups" }
   else
-
   # Check for venue information
-  if @results["venue"]
-    @name = @results["venue"]["name"]
-    @lat = @results["venue"]["lat"]
-    @lon = @results["venue"]["lon"]
-    location = "<http://www.google.com/maps/place/#{@lat},#{@lon}|#{@name}>"
+  if @firstresults["venue"]
+    @name = @firstresults["venue"]["name"]
+    @lat = @firstresults["venue"]["lat"]
+    @lon = @firstresults["venue"]["lon"]
+    firstlocation = "<http://www.google.com/maps/place/#{@lat},#{@lon}|#{@name}>"
   else
-    location = "No location provided"
+    firstlocation = "No location provided"
   end
+  get_firstname = @firstresults["name"]
+  get_firsturl = @firstresults["event_url"]
+  raw_firsttime = @firstresults["time"].to_f / 1000
+  utc_firstoffset = @firstresults["utc_offset"].to_i / 1000
+  calc_firsttime = Time.at(raw_time).getlocal(utc_offset)
+  cldr_firsttime = calc_firsttime.localize
+  get_firsttime = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
 
-  get_name = @results["name"]
+  # Second Meetup
+  if @secondresults.nil?
+    get_secondname = ""
+    get_secondurl = ""
+    get_secondtime = ""
+    secondlocation = ""
+  else
+  # Check for venue information
+  if @secondresults["venue"]
+    @name = @secondresults["venue"]["name"]
+    @lat = @secondresults["venue"]["lat"]
+    @lon = @secondresults["venue"]["lon"]
+    secondlocation = "<http://www.google.com/maps/place/#{@lat},#{@lon}|#{@name}>"
+  else
+    secondlocation = "No location provided"
+  end
+  get_secondname = @secondresults["name"]
+  get_secondurl = @secondresults["event_url"]
+  raw_secondtime = @secondresults["time"].to_f / 1000
+  utc_secondoffset = @secondresults["utc_offset"].to_i / 1000
+  calc_secondtime = Time.at(raw_time).getlocal(utc_offset)
+  cldr_secondtime = calc_secondtime.localize
+  get_secondtime = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
 
-  get_url = @results["event_url"]
-
-  raw_time = @results["time"].to_f / 1000
-  utc_offset = @results["utc_offset"].to_i / 1000
-  calc_time = Time.at(raw_time).getlocal(utc_offset)
-  cldr_time = calc_time.localize
-  get_time = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
-
-  response = { title: "#{get_name}", title_link: "#{get_url}", text: "#{get_time}\n#{location}", color: "#{ENV["COLOR"]}"}
+  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firstime}\n#{firstlocation}", color: "#{ENV["COLOR"]}"}
 
   end
 

--- a/app.rb
+++ b/app.rb
@@ -58,6 +58,7 @@ def generate_attachment
   calc_firsttime = Time.at(raw_time).getlocal(utc_offset)
   cldr_firsttime = calc_firsttime.localize
   get_firsttime = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
+  end
 
   # Second Meetup
   if @secondresults.nil?
@@ -84,7 +85,6 @@ def generate_attachment
   get_secondtime = "#{cldr_time.to_short_s} #{cldr_time.to_date.to_full_s}"
 
   response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firstime}\n#{firstlocation}", color: "#{ENV["COLOR"]}"}
-
   end
 
 end

--- a/app.rb
+++ b/app.rb
@@ -86,7 +86,7 @@ def generate_attachment
   cldr_secondtime = calc_secondtime.localize
   get_secondtime = "#{cldr_secondtime.to_short_s} #{cldr_secondtime.to_date.to_full_s}"
 
-  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", color: "#{ENV["COLOR"]}", fields: [ { title: "RSVPs", value: "#{get_firstrsvpcount}", short: true }, { title: "Waitlist", value: "#{get_firstwaitlistcount}", short: true }, { title: "Following Meetup:", value: "<#{get_secondurl}|#{get_secondname}> - #{get_secondtime}", short: false } ] }
+  response = { title: "#{get_firstname}", title_link: "#{get_firsturl}", text: "#{get_firsttime}\n#{firstlocation}", fields: [ { title: "RSVPs", value: "#{get_firstrsvpcount}", short: true }, { title: "Waitlist", value: "#{get_firstwaitlistcount}", short: true }, { title: "Following Meetup:", value: "<#{get_secondurl}|#{get_secondname}> - #{get_secondtime}", short: false } ] }
   end
 
 end

--- a/app.rb
+++ b/app.rb
@@ -36,7 +36,7 @@ def generate_attachment
 if user_query.nil?
   uri = "https://api.meetup.com/2/events?group_id=#{ENV["MEETUP_GROUP_ID"]}&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 else
-  uri = "https://api.meetup.com/2/open_events?topic='#{user_query}''&page=2&key=#{ENV["MEETUP_API_KEY"]}"
+  uri = "https://api.meetup.com/2/open_events?text='#{user_query}''&page=2&key=#{ENV["MEETUP_API_KEY"]}"
 end
   request = HTTParty.get(uri)
   puts "[LOG] #{request.body}"


### PR DESCRIPTION
### Summary

This makes some significant changes to the way the bot fetches and displays information. Leaving the PR open right now because I may re-visit it in the future.
### Changes
- Switched from using `group-url` to `group id` for identifying groups. This is a little more difficult to find (you will need to do an initial API call to see the group id for a Meetup group) but allows you to enter multiple groups in the environment variable to pull the next available Meetup from.
- Change the formatting around to show the Next Meetup and the Following Meetup. Now that we have the ability to pull from multiple groups we can show more results in the response. I also added short fields to show the RSVP and Waitlist numbers. Ex:

![screen shot 2015-10-20 at 11 57 04 am](https://cloud.githubusercontent.com/assets/4997935/10620931/ae868b54-774b-11e5-9855-c725c643fecb.png)

![screen shot 2015-10-20 at 11 56 46 am](https://cloud.githubusercontent.com/assets/4997935/10620937/b2d5c6c0-774b-11e5-8a5c-f208373c3e6a.png)
- Implemented a topic search. If you just use the trigger word it will return the information for the Meetups listed in the `group id` environment variable. If you add a topic to the trigger word it will look for the next occurring Meetups within the zip code (defined by the `ZIP_CODE` environment variable) that are are within the topic.
- Made a slight regression in calculating the UTC offset. This was necessary to get the proper Meetup times to display. It's crude but it should still work just as well as the previous method.
